### PR TITLE
bugfix: allow adding stories to projects

### DIFF
--- a/ProjMgmt/requirements/views/stories.py
+++ b/ProjMgmt/requirements/views/stories.py
@@ -50,12 +50,14 @@ def new_story(request, projectID):
         form = StoryForm(project=project)
         # formset = TaskFormSet(instance=story)
         # formset.extra = 1
-        
+    project = project_api.get_project(projectID)
+    association = UserAssociation.objects.get(user=request.user, project=project)    
     context = {'title' : 'New User Story',
                'form' : form,
                # 'formset' : formset,
                'action' : '/req/newstory/' + projectID , 
-               'button_desc' : 'Create User Story' }
+               'button_desc' : 'Create User Story',
+               'project' : project, 'association' : association}
     return render(request, 'StorySummary.html', context )
 
 @login_required(login_url='/signin')


### PR DESCRIPTION
There is still a problem with form validation. If the form fails validation we do not correctly display error messages, we return the entire form which does not render correctly.
